### PR TITLE
allow passing of custom servemux to Run

### DIFF
--- a/registry/cmd/main.go
+++ b/registry/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"net"
+	"net/http"
 
 	"github.com/burgerdev/evil-registry/registry"
 )
@@ -18,5 +19,5 @@ func main() {
 		log.Fatalf("Could not listen on %s: %v", *addr, err)
 	}
 	log.Printf("serving a registry on %s ...", *addr)
-	registry.Run(listener)
+	registry.Run(listener, http.DefaultServeMux)
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -102,10 +102,10 @@ func v2Handler(rw http.ResponseWriter, _ *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 }
 
-func Run(listener net.Listener) {
-	http.DefaultServeMux.Handle("/v2/busybox/manifests/{digest}", http.HandlerFunc(manifestHandler))
-	http.DefaultServeMux.Handle("/v2/busybox/blobs/{digest}", http.HandlerFunc(blobHandler))
-	http.DefaultServeMux.Handle("/v2/", http.HandlerFunc(v2Handler))
+func Run(listener net.Listener, mux *http.ServeMux) {
+	mux.Handle("/v2/busybox/manifests/{digest}", http.HandlerFunc(manifestHandler))
+	mux.Handle("/v2/busybox/blobs/{digest}", http.HandlerFunc(blobHandler))
+	mux.Handle("/v2/", http.HandlerFunc(v2Handler))
 
-	http.Serve(listener, http.DefaultServeMux)
+	http.Serve(listener, mux)
 }


### PR DESCRIPTION
Oversight on my part: the previous version worked for *one* test, but reusing `http.DefaultServeMux` resulted in errors when duplicate ServeMuxes were being added.

This has been tested against the current state of https://github.com/edgelesssys/contrast/pull/1628.